### PR TITLE
add OP_CHECKCOLDSTAKEVERIFY_LOF

### DIFF
--- a/bchain/coins/pivx/pivxparser.go
+++ b/bchain/coins/pivx/pivxparser.go
@@ -39,7 +39,8 @@ const (
     OP_CHECKSIG = 0xac
     OP_ZEROCOINMINT  = 0xc1
     OP_ZEROCOINSPEND  = 0xc2
-    OP_CHECKCOLDSTAKEVERIFY = 0xd1
+    OP_CHECKCOLDSTAKEVERIFY_LOF = 0xd1
+    OP_CHECKCOLDSTAKEVERIFY = 0xd2
 
     // Labels
     ZCMINT_LABEL = "Zerocoin Mint"
@@ -340,7 +341,7 @@ func IsP2CSScript(signatureScript []byte) bool {
            signatureScript[1] == OP_HASH160 &&
            signatureScript[2] == OP_ROT &&
            signatureScript[3] == OP_IF &&
-           signatureScript[4] == OP_CHECKCOLDSTAKEVERIFY &&
+           (signatureScript[4] == OP_CHECKCOLDSTAKEVERIFY || signatureScript[4] == OP_CHECKCOLDSTAKEVERIFY_LOF) &&
            signatureScript[5] == 0x14 &&
            signatureScript[26] == OP_ELSE &&
            signatureScript[27] == 0x14 &&

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -524,10 +524,11 @@ func (d *RocksDB) GetAndResetConnectBlockStats() string {
 }
 
 // PIVX
-const OP_CHECKCOLDSTAKEVERIFY = 0xd1
+const OP_CHECKCOLDSTAKEVERIFY_LOF = 0xd1
+const OP_CHECKCOLDSTAKEVERIFY = 0xd2
 
 func isPayToColdStake(signatureScript []byte) bool {
-    return len(signatureScript) > 50 && signatureScript[4] == OP_CHECKCOLDSTAKEVERIFY
+    return len(signatureScript) > 50 && (signatureScript[4] == OP_CHECKCOLDSTAKEVERIFY || signatureScript[4] == OP_CHECKCOLDSTAKEVERIFY_LOF)
 }
 
 func getOwnerFromP2CS(signatureScript []byte) ([]byte, error) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Could this be related to or even fix #8 ?

Only opcode OP_CHECKCOLDSTAKEVERIFY is used to identify _Cold Staking Contracts_.
And opcode OP_CHECKCOLDSTAKEVERIFY [0xd1] differs from PIVX [0xd2]

PIVX changed the name of opcode OP_CHECKCOLDSTAKEVERIFY to OP_CHECKCOLDSTAKEVERIFY_LOF
And added a new opcode OP_CHECKCOLDSTAKEVERIFY [0xd2]
https://github.com/PIVX-Project/PIVX/pull/2275
## What was done?
Change opcode OP_CHECKCOLDSTAKEVERIFY to OP_CHECKCOLDSTAKEVERIFY_LOF
Add opcode OP_CHECKCOLDSTAKEVERIFY [0xd2]
Use both opcodes to check if it is a Pay to ColdStake Script
## How Has This Been Tested?
~~It has not been tested. I could not get the go compiler working on my machine (yet), but could not wait to share.~~
## Breaking Changes
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas